### PR TITLE
Migrate to CompletableFuture / HttpClient usage, misc changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11, 17, 19]
+        java: [11, 17, 19]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Java
@@ -16,7 +16,5 @@ jobs:
           cache: 'gradle'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-      - name: init submodule
-        run: git submodule init && git submodule update
       - name: Build with Gradle
         run: ./gradlew build --no-daemon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 - Update dependencies
-- mark the client property of UploadLogResponse as transient
-  - This should fix an issue with deserialization on Java 17+
+- Utilize `CompletableFuture` to wrap around API calls
+- API calls are now async
+- Moved visibility of all fields to `private`, some are also `final`
+- Utilizes Java 11s `HttpClient`

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.3'
 
     implementation 'com.google.code.gson:gson:2.10.1'
 }

--- a/src/main/java/gs/mclo/api/APIException.java
+++ b/src/main/java/gs/mclo/api/APIException.java
@@ -5,7 +5,7 @@ import gs.mclo.api.response.JsonResponse;
 import java.io.IOException;
 
 public class APIException extends IOException {
-    protected JsonResponse response;
+    protected final JsonResponse response;
 
     public APIException(JsonResponse response) {
         super("The API returned an error");

--- a/src/main/java/gs/mclo/api/Instance.java
+++ b/src/main/java/gs/mclo/api/Instance.java
@@ -1,8 +1,8 @@
 package gs.mclo.api;
 
 public class Instance {
-    protected String apiBaseUrl;
-    protected String viewLogUrl;
+    private String apiBaseUrl;
+    private String viewLogUrl;
 
     /**
      * Create a new Instance with the default API base URL and view log URL

--- a/src/main/java/gs/mclo/api/Log.java
+++ b/src/main/java/gs/mclo/api/Log.java
@@ -15,7 +15,7 @@ public class Log {
     /**
      * log content
      */
-    protected String content;
+    private String content;
 
     /**
      * pattern for IPv4 addresses
@@ -117,7 +117,7 @@ public class Log {
      */
     private void filterIPv4() {
         Matcher matcher = IPV4_PATTERN.matcher(this.content);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (matcher.find()) {
             if (isWhitelistedIPv4(matcher.group())) {
                 continue;
@@ -147,7 +147,7 @@ public class Log {
      */
     private void filterIPv6() {
         Matcher matcher = IPV6_PATTERN.matcher(this.content);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (matcher.find()) {
             if (isWhitelistedIPv6(matcher.group())) {
                 continue;

--- a/src/main/java/gs/mclo/api/Util.java
+++ b/src/main/java/gs/mclo/api/Util.java
@@ -1,15 +1,35 @@
 package gs.mclo.api;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import com.google.gson.Gson;
+
+import java.io.*;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 public class Util {
+
+    public static String[] listFilesInDirectory(File file) {
+        if(!file.exists())
+            return new String[0];
+        String[] files = file.list();
+        if (files == null)
+            files = new String[0];
+
+        return Arrays.stream(files)
+                .filter(f -> f.matches(Log.ALLOWED_FILE_NAME_PATTERN.pattern()))
+                .sorted()
+                .toArray(String[]::new);
+    }
+
+    public static <T> HttpResponse.BodyHandler<T> parseResponse(Class<T> clazz, Gson gson) {
+        return responseInfo -> HttpResponse.BodySubscribers.mapping(HttpResponse.BodySubscribers.ofString(StandardCharsets.UTF_8),
+                body -> gson.fromJson(body, clazz));
+    }
 
     /**
      * parse an input stream to a string

--- a/src/main/java/gs/mclo/api/response/InsightsResponse.java
+++ b/src/main/java/gs/mclo/api/response/InsightsResponse.java
@@ -7,27 +7,27 @@ public class InsightsResponse extends JsonResponse {
     /**
      * ID of detected log (name/type) e.g. "vanilla/server"
      */
-    protected String id = null;
+    private String id = null;
 
     /**
      * Software name, e.g. "Vanilla"
      */
-    protected String name = null;
+    private String name = null;
 
     /**
      * Software type, e.g. "server"
      */
-    protected String type = null;
+    private String type = null;
 
     /**
      * Combined title, e.g. "Vanilla 1.12.2 Server Log"
      */
-    protected String title = null;
+    private String title = null;
 
     /**
      * Information obtained from the analysis of the log
      */
-    protected Analysis analysis = null;
+    private Analysis analysis = null;
 
     /**
      * Get the ID of detected log (name/type) e.g. "vanilla/server"

--- a/src/main/java/gs/mclo/api/response/JsonResponse.java
+++ b/src/main/java/gs/mclo/api/response/JsonResponse.java
@@ -3,8 +3,8 @@ package gs.mclo.api.response;
 import gs.mclo.api.APIException;
 
 public class JsonResponse {
-    protected boolean success = true;
-    protected String error = null;
+    private boolean success = true;
+    private String error = null;
 
     /**
      * was the upload successful?

--- a/src/main/java/gs/mclo/api/response/UploadLogResponse.java
+++ b/src/main/java/gs/mclo/api/response/UploadLogResponse.java
@@ -3,10 +3,11 @@ package gs.mclo.api.response;
 import gs.mclo.api.MclogsClient;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 
 public class UploadLogResponse extends JsonResponse {
-    protected String id = null;
-    protected transient MclogsClient client;
+    private String id = null;
+    private transient MclogsClient client;
 
     /**
      * set the client used to upload this log
@@ -46,16 +47,15 @@ public class UploadLogResponse extends JsonResponse {
      * @return the raw content of this log
      * @throws IOException if an error occurs while fetching the content
      */
-    public String getRawContent() throws IOException {
+    public CompletableFuture<String> getRawContent() throws IOException {
         return this.client.getRawLogContent(this.id);
     }
 
     /**
      * Fetch the insights for this log
      * @return the insights for this log
-     * @throws IOException if an error occurs while fetching the insights
      */
-    public InsightsResponse getInsights() throws IOException {
+    public CompletableFuture<InsightsResponse> getInsights() {
         return this.client.getInsights(this.id);
     }
 }

--- a/src/test/java/gs/mclo/api/APITest.java
+++ b/src/test/java/gs/mclo/api/APITest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -82,15 +83,17 @@ public class APITest {
     void shareLog() {
         assertDoesNotThrow(() -> {
             MclogsClient client = new MclogsClient("aternos/mclogs-java-tests");
-            UploadLogResponse response = client.uploadLog(Paths.get("src/test/resources/logs/one.log"));
-            assertTrue(response.isSuccess());
-            assertNotNull(response.getId());
-            assertNotNull(response.getUrl());
-            assertNull(response.getError());
-            String rawLog = response.getRawContent();
-            assertEquals(Util.getFileContents("src/test/resources/logs/one.log"), rawLog);
+            CompletableFuture<UploadLogResponse> response = client.uploadLog(Paths.get("src/test/resources/logs/one.log"));
+            UploadLogResponse res = response.get();
+            res.setClient(client);
+            assertTrue(res.isSuccess());
+            assertNotNull(res.getId());
+            assertNotNull(res.getUrl());
+            assertNull(res.getError());
+            CompletableFuture<String> rawLog = res.getRawContent();
+            assertEquals(Util.getFileContents("src/test/resources/logs/one.log"), rawLog.get());
 
-            System.out.println("Test log has been shared at " + response.getUrl());
+            System.out.println("Test log has been shared at " + res.getUrl());
         });
     }
 
@@ -98,15 +101,17 @@ public class APITest {
     void shareGzipLog() {
         assertDoesNotThrow(() -> {
             MclogsClient client = new MclogsClient("aternos/mclogs-java-tests");
-            UploadLogResponse response = client.uploadLog(Paths.get("src/test/resources/logs/three.log.gz"));
-            assertTrue(response.isSuccess());
-            assertNotNull(response.getId());
-            assertNotNull(response.getUrl());
-            assertNull(response.getError());
-            String rawLog = response.getRawContent();
-            assertEquals(Util.getGZIPFileContents("src/test/resources/logs/three.log.gz"), rawLog);
+            CompletableFuture<UploadLogResponse> response = client.uploadLog(Paths.get("src/test/resources/logs/three.log.gz"));
+            UploadLogResponse res = response.get();
+            res.setClient(client);
+            assertTrue(res.isSuccess());
+            assertNotNull(res.getId());
+            assertNotNull(res.getUrl());
+            assertNull(res.getError());
+            CompletableFuture<String> rawLog = res.getRawContent();
+            assertEquals(Util.getGZIPFileContents("src/test/resources/logs/three.log.gz"), rawLog.get());
 
-            System.out.println("Gzip test log has been shared at " + response.getUrl());
+            System.out.println("Gzip test log has been shared at " + res.getUrl());
         });
     }
 
@@ -144,15 +149,17 @@ public class APITest {
 
             MclogsClient client = new MclogsClient("aternos/mclogs-java-tests")
                     .setInstance(instance);
-            UploadLogResponse response = client.uploadLog(Util.getFileContents("src/test/resources/logs/one.log"));
-            assertTrue(response.isSuccess());
-            assertNotNull(response.getId());
-            assertNotNull(response.getUrl());
-            assertNull(response.getError());
-            String rawLog = response.getRawContent();
-            assertEquals(Util.getFileContents("src/test/resources/logs/one.log"), rawLog);
+            CompletableFuture<UploadLogResponse> response = client.uploadLog(Util.getFileContents("src/test/resources/logs/one.log"));
+            UploadLogResponse res = response.get();
+            res.setClient(client);
+            assertTrue(res.isSuccess());
+            assertNotNull(res.getId());
+            assertNotNull(res.getUrl());
+            assertNull(res.getError());
+            CompletableFuture<String> rawLog = res.getRawContent();
+            assertEquals(Util.getFileContents("src/test/resources/logs/one.log"), rawLog.get());
 
-            System.out.println("Test log has been shared at " + response.getUrl());
+            System.out.println("Test log has been shared at " + res.getUrl());
         });
     }
 
@@ -160,19 +167,22 @@ public class APITest {
     void getLogInsights() {
         assertDoesNotThrow(() -> {
             MclogsClient client = new MclogsClient("aternos/mclogs-java-tests");
-            UploadLogResponse response = client.uploadLog(Paths.get("src/test/resources/logs/three.log.gz"));
-            assertTrue(response.isSuccess());
-            assertNotNull(response.getId());
-            assertNotNull(response.getUrl());
-            assertNull(response.getError());
-            InsightsResponse insights = response.getInsights();
+            CompletableFuture<UploadLogResponse> response = client.uploadLog(Paths.get("src/test/resources/logs/three.log.gz"));
+            UploadLogResponse res = response.get();
+            res.setClient(client);
+            assertTrue(res.isSuccess());
+            assertNotNull(res.getId());
+            assertNotNull(res.getUrl());
+            assertNull(res.getError());
+            CompletableFuture<InsightsResponse> insightsResponse = res.getInsights();
+            InsightsResponse insights = insightsResponse.get();
             assertNotNull(insights);
             assertTrue(insights.isSuccess());
             assertNotNull(insights.getAnalysis());
             assertNotNull(insights.getAnalysis().getInformation());
             assertNotNull(insights.getAnalysis().getProblems());
 
-            System.out.println("Gzip test log has been shared at " + response.getUrl());
+            System.out.println("Gzip test log has been shared at " + res.getUrl());
         });
     }
 }


### PR DESCRIPTION
This is most absolutely breaking backwards compat, but I believe it's worth it
This migrates off of Java 8 fully, making use of Java 11's `HttpClient` (if you want to maintain Java 8 compat, easy enough to just use a different library)
Changes list 
- Adjusted all fields to be `private`, and where necessary, `final`
- Remove redundant git submodules step from building 
- Migrated off of legacy Java http connections, making use of their Java [HttpClient](https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpClient.html)
- All API based methods now are wrapped around a `CompletableFuture`, as they are all ran async 
- Made some misc changes 

Fully aware that this would break every mclogs based plugin - more than happy to PR relevant changes if this is approved and implemented